### PR TITLE
Support for False-ish Owner Names like Empty Strings

### DIFF
--- a/lib/task-sharding.js
+++ b/lib/task-sharding.js
@@ -118,7 +118,7 @@ class TaskSharding extends EventEmitter {
      * @memberof TaskSharding
      */
     _performUpdate() {
-        if (!this.selfNode) {
+        if (typeof this.selfNode !== 'string') {
             //The update will be scheduled once selfNode will be set.
             return;
         }
@@ -149,7 +149,7 @@ class TaskSharding extends EventEmitter {
      * @memberof TaskSharding
      */
     _isSelf(node) {
-        return typeof this.selfNode !== 'undefined' && node === this.selfNode;
+        return typeof this.selfNode === 'string' && node === this.selfNode;
     }
 
     /**
@@ -217,7 +217,7 @@ class TaskSharding extends EventEmitter {
         if(this._selfNode === value) {
             return;
         }
-        if(this._selfNode) {
+        if(typeof this._selfNode === 'string') {
             throw new Error('Cannot update selfNode');
         }
 
@@ -235,7 +235,7 @@ class TaskSharding extends EventEmitter {
      */
     removeTask(id) {
         const owner = this._taskOwnership.get(id);
-        if(owner) {
+        if(typeof owner === 'string') {
             this._taskOwnership.delete(id);
             if(this._isSelf(owner)) {
                 super.emit(TASK_REVOKED_EVENT, id);
@@ -255,7 +255,7 @@ class TaskSharding extends EventEmitter {
      */
     addTask(id) {
         let owner = this._taskOwnership.get(id);
-        if(!owner) {
+        if(typeof owner !== 'string') {
             owner = this._hashring.get(id);
             this._taskOwnership.set(id, owner);
             if(this._isSelf(owner)) {

--- a/lib/task-sharding.js
+++ b/lib/task-sharding.js
@@ -220,6 +220,9 @@ class TaskSharding extends EventEmitter {
         if(typeof this._selfNode === 'string') {
             throw new Error('Cannot update selfNode');
         }
+        if(typeof value !== 'string') {
+            throw new Error('selfNode must be of type "string"');
+        }
 
         this._selfNode = value;
         this._scheduleUpdate();

--- a/test/task-shard-test.js
+++ b/test/task-shard-test.js
@@ -152,4 +152,15 @@ describe('Task Sharding Tests', () => {
     //     configMonitorMock.emit('configsAdded',{task1:{ name: "hello" }});
     //     clusterMonitorMock.emit('clusterChange',"node1",["node1"]);
     // });
+
+    it('test addTask and removeTask in case of false-ish owner names like empty strings', () => {
+        const myTask = 'hello world';
+        this.gts.addTask(myTask);
+        this.gts.addNode(['']);
+        this.gts.selfNode = '';
+        return this.expectOwnerships([myTask])
+            .then(() => {
+                expect(this.gts.removeTask(myTask)).to.equal(true);
+            });
+    });
 });


### PR DESCRIPTION
*(as a result of #1)*

With this PR, 'task-sharding' works fine with false-ish owner names like empty strings. Also includes an unit tests which covers this edge case.

Also enforces that `selfNode` is of type string, since the hashring implementation also works with strings (or converts the provided values to strings)... so e.g. `hashring.get` always returns a string.